### PR TITLE
VI-4920 Add keyboard-map to iframe allow attribute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -247,7 +247,7 @@ function App() {
                         backgroundColor: 'black',
                       }}
                       title="Content Frame"
-                      allow="autoplay; fullscreen; microphone; camera; midi; encrypted-media; picture-in-picture; display-capture; clipboard-read; clipboard-write"
+                      allow="autoplay; fullscreen; microphone; camera; midi; encrypted-media; picture-in-picture; display-capture; clipboard-read; clipboard-write; keyboard-map"
                   />
                 </Box>
             )}


### PR DESCRIPTION
## JIRA

[VI-4920 — Embed test tool iframe missing keyboard-map permission policy](https://cuttingroom.atlassian.net/browse/VI-4920)

## What does this PR do?

Adds `keyboard-map` to the embedded iframe's `allow` attribute.

Embedded CuttingRoom calls `navigator.keyboard.getLayoutMap()` (in `vimond.io/src/modules/keybindings/get-keyboard-layout-key-map.ts`) to map keyboard shortcuts to the user's physical keyboard layout. That API is gated by the `keyboard-map` Permissions Policy feature, whose default allowlist is `self` — so it works in a top-level tab but is blocked in a cross-origin iframe, producing:

```
Could not read keyboard layout map. Falling back to standard QWERTY layout.
SecurityError: getLayoutMap() must be called from a top-level browsing context or allowed by the permission policy.
```

Delegating `keyboard-map` via the iframe `allow` attribute silences the warning and gives correct layout mapping in the embed.

## Manual Testing

1. Run the embed test tool, load an embedded CuttingRoom URL.
2. Open the browser console — the `getLayoutMap()` SecurityError / QWERTY-fallback warning no longer appears.

## Notes

Low impact — CuttingRoom already catches the error and falls back to QWERTY, so this only removes a console warning and fixes shortcut-to-key mapping on non-QWERTY keyboards. Real partner embeds need the same `keyboard-map` entry in their own iframe `allow` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)